### PR TITLE
Add support for Symfony 6.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [7.1, 7.2, 7.3, 7.4, 8.0]
+                php: [8.0, 8.1, 8.2]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,28 +6,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.2.0] - 2023-08-03
+## [3.0.0] - 2023-08-08
+
 ### Added
+
 - Support for phpunit ~10.0.
 
 ### Removed
+
 - Support for PHP < 8.0.
 
 ## [2.1.2] - 2022-01-07
+
 ### Changed
+
 - Allowed versions of psr/log to account for PHP 8.
 
 ## [2.1.1] - 2021-11-17
+
 ### Fixed
+
 - Type from `int` to `?float` for `setCommandTimeout()` to match `Symfony\Component\Process\Process::setTimeout(?float)`.
 
 ## [2.1.0] - 2021-10-29
 
 ### Added
+
 - Type hinting for both function parameters and returns.
 - Support for symfony/process ~5.0.
 
 ### Changed
+
 - Minimum supported PHP version to 7.1.3.
 - PHPUnit to v8.0.
 
@@ -43,8 +52,8 @@ Please update me.
 
 Please update me.
 
-[Unreleased]: https://github.com/trafficgate/shell-command/compare/v2.2.0...HEAD
-[2.1.2]: https://github.com/trafficgate/shell-command/compare/v2.1.2...v2.2.0
+[Unreleased]: https://github.com/trafficgate/shell-command/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/trafficgate/shell-command/compare/v2.1.2...v3.0.0
 [2.1.2]: https://github.com/trafficgate/shell-command/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/trafficgate/shell-command/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/trafficgate/shell-command/compare/v2.0.0...v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2023-08-03
+### Added
+- Support for phpunit ~10.0.
+
+### Removed
+- Support for PHP < 8.0.
+
 ## [2.1.2] - 2022-01-07
 ### Changed
 - Allowed versions of psr/log to account for PHP 8.
@@ -36,7 +43,8 @@ Please update me.
 
 Please update me.
 
-[Unreleased]: https://github.com/trafficgate/shell-command/compare/v2.1.2...HEAD
+[Unreleased]: https://github.com/trafficgate/shell-command/compare/v2.2.0...HEAD
+[2.1.2]: https://github.com/trafficgate/shell-command/compare/v2.1.2...v2.2.0
 [2.1.2]: https://github.com/trafficgate/shell-command/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/trafficgate/shell-command/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/trafficgate/shell-command/compare/v2.0.0...v2.1.0

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^7.1|^8.0",
         "psr/log": "^1.0|^2.0|^3.0",
-        "symfony/process": "~3.0|~4.0|~5.0"
+        "symfony/process": "~3.0|~4.0|~5.0|~6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^8.0",
         "psr/log": "^1.0|^2.0|^3.0",
         "symfony/process": "~3.0|~4.0|~5.0|~6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~3.0",
-        "phpunit/phpunit": "~6.0|~7.0|~8.0|~9.0"
+        "phpunit/phpunit": "~9.0|~10.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ShellCommand.php
+++ b/src/ShellCommand.php
@@ -529,6 +529,7 @@ abstract class ShellCommand
     private function compile(): Process
     {
         $shellOptions = [];
+
         /** @var ShellOption $shellOption */
         foreach ($this->shellOptions as $shellOption) {
             $shellOptions = array_merge($shellOptions, $shellOption->getArray());

--- a/src/ShellCommand.php
+++ b/src/ShellCommand.php
@@ -235,8 +235,6 @@ abstract class ShellCommand
      *
      * Return null if the argument isn't found.
      *
-     * @param $key
-     *
      * @return mixed
      */
     final public function argument(string $key)
@@ -264,8 +262,6 @@ abstract class ShellCommand
 
     /**
      * Get a specific option.
-     *
-     * @param $flag
      *
      * @return mixed
      */

--- a/src/ShellOption.php
+++ b/src/ShellOption.php
@@ -87,9 +87,9 @@ final class ShellOption
      *
      * @param bool|true $enable
      *
-     * @throws InvalidArgumentException
-     *
      * @return $this
+     *
+     * @throws InvalidArgumentException
      */
     public function enable(bool $enable = true): ShellOption
     {
@@ -271,7 +271,7 @@ final class ShellOption
         $pattern = '/^' . // Match start of string
             '(' . // Start Group
                 '(?<flag>(?:-\w|--\w[\w-]+))' . // Match Group <flag>
-                '(?<enable>\+)?' . //Enable option by default (useful for creating special commands)
+                '(?<enable>\+)?' . // Enable option by default (useful for creating special commands)
             ')' . // End Group
             '(' . // Start Group
                 '(?<can_have_value>=)?' . // Match Group <can_have_value>
@@ -344,9 +344,9 @@ final class ShellOption
     /**
      * Set the flag.
      *
-     * @throws InvalidArgumentException
-     *
      * @return $this
+     *
+     * @throws InvalidArgumentException
      */
     private function setFlag(string $flag): ShellOption
     {
@@ -362,9 +362,9 @@ final class ShellOption
     /**
      * Set whether the flag can have a value or not.
      *
-     * @throws InvalidArgumentException
-     *
      * @return $this
+     *
+     * @throws InvalidArgumentException
      */
     private function setCanHaveValue(bool $canHaveValue): ShellOption
     {
@@ -380,9 +380,9 @@ final class ShellOption
     /**
      * Set whether the flag can have multiple values or not.
      *
-     * @throws InvalidArgumentException
-     *
      * @return $this
+     *
+     * @throws InvalidArgumentException
      */
     private function setCanHaveMultipleValues(bool $canHaveMultipleValues): ShellOption
     {


### PR DESCRIPTION
- Added support for PHP8, dropped support for PHP7
- Added phpunit v10
- Added support for Symfony 6.
- Fixed a bug where the flag was not being set correctly when using ShellOption::enable().
- Improved code readability by moving some methods to private scope and adding PHPDocs comments in them, as well as fixing typos on existing ones (e.g., "Enable option" instead of "Enables option").